### PR TITLE
Update OB.php

### DIFF
--- a/lib/core/OB.php
+++ b/lib/core/OB.php
@@ -173,7 +173,9 @@ class OB{
                 'Agencia' => $this->Vendedor->Agencia,
                 'Carteira' => $this->Vendedor->Carteira,
                 'Conta' => $this->Vendedor->Conta,
+                'DigitoConta' => $this->Vendedor->DigitoConta,
                 'NossoNumero' => $this->Boleto->NossoNumero,
+                'DigitoNossoNumero' => $this->Boleto->DigitoNossoNumero,
                 'FatorVencimento' => $this->Boleto->FatorVencimento,
                 'CodigoCedente' => $this->Vendedor->CodigoCedente,
                );


### PR DESCRIPTION
Nos comentários diz que na versão 0.3 de 25/05/2011, foi adicionado os campos "DigitoNossoNumero" e "DigitoConta". Porém, não foram inseridos no core. Por isso, o Bradesco não gerava boletos pela falta desses dados.
