### PR TITLE
Correção cálculo duplo dígito Banrisul

### DIFF
--- a/lib/bancos/Banrisul.php
+++ b/lib/bancos/Banrisul.php
@@ -151,13 +151,14 @@ Nota: Mesmo Não Constando No Exemplo, O Número Do Título Para O Banco Sempre 
         #concatenando agora o novo $dv1
         if($dv2 == 10){
             $dv1++;
-            $dv2 = Math::Mod11($num . $dv1, 10, 0, false, 7);
             
             #Se o novo valor de $dv1 for maior que 9, então
             #$dv1 passará a ser 0
             if($dv1 > 9){
                 $dv1 = 0;
             }
+            
+            $dv2 = Math::Mod11($num . $dv1, 10, 0, false, 7);
         }
         
         return $dv1 . $dv2;


### PR DESCRIPTION
Novo cálculo do Mod11 deve ser feito após somar dv1+1 e verificar se este é > 9.

Descobri esse erro ao calcular o DV do número 393, que resultava em dv1 = 9 e dv2 = 10, sendo assim, somado dv1+1, o mod11 era recalculado como 39310, resultando dv=010 (dv1=0 e dv2=10), ou seja, 3 dígitos e ainda com o problema do dv2=10.

O correto é, ao somar dv1+1, e caso o resultado >9, dv1 será 0, recalculando o mod11 com 3930, resultando em dv=06 (dv1=0 e dv2=6).

Portanto a solução no código é somente reposicionar o segundo cálculo do mod11 para depois da verificação dv1>9.

Recalculei com esse ajuste e descobri que os números 265 e 270 apresentaram problema também. De fato o cliente não conseguiu pagar esses boletos.